### PR TITLE
Fix failing .dir-locals

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -10,7 +10,7 @@
       (message "START: ii/sql-org-hacks")
       ;; ensure tmpdir is in home dir so noexec / tmp doesn't fail
       (set (make-local-variable 'temporary-file-directory)
-           (concat user-home-directory "tmp/"))
+           (concat (getenv "HOME") "/tmp/"))
       (mkdir temporary-file-directory t)
       (set (make-local-variable 'org-babel-temporary-directory)
            (concat temporary-file-directory "babel"))


### PR DESCRIPTION
Loading `.dir-locals` fails when trying to create `temporary-file-directory` as `user-home-directory` is void.
```
      (set (make-local-variable 'temporary-file-directory)
           (concat user-home-directory "tmp/"))
```
```
File local-variables error: (void-variable user-home-directory)
```
Switching to use `HOME` means that all the setting including apisnoop database connection now load.